### PR TITLE
Partial port to Darwin

### DIFF
--- a/libc/c_errno.c2i
+++ b/libc/c_errno.c2i
@@ -6,7 +6,7 @@ import c2 local;
 // #define errno *errno_location()
 
 c_int errno;
-#if DARWIN_ARM64
+#if SYSTEM_DARWIN
 fn c_int* __error();
 fn c_int* errno2() @(cname="__error");
 #else
@@ -14,7 +14,7 @@ fn c_int* __errno_location();
 fn c_int* errno2() @(cname="__errno_location");
 #endif
 
-#if DARWIN_ARM64
+#if SYSTEM_DARWIN
 const i32 EPERM        =   1;  /* Operation not permitted */
 const i32 ENOENT       =   2;  /* No such file or directory */
 const i32 ESRCH        =   3;  /* No such process */

--- a/libc/c_errno.c2i
+++ b/libc/c_errno.c2i
@@ -6,10 +6,53 @@ import c2 local;
 // #define errno *errno_location()
 
 c_int errno;
+#if DARWIN_ARM64
+fn c_int* __error();
+fn c_int* errno2() @(cname="__error");
+#else
 fn c_int* __errno_location();
-
 fn c_int* errno2() @(cname="__errno_location");
+#endif
 
+#if DARWIN_ARM64
+const i32 EPERM        =   1;  /* Operation not permitted */
+const i32 ENOENT       =   2;  /* No such file or directory */
+const i32 ESRCH        =   3;  /* No such process */
+const i32 EINTR        =   4;  /* Interrupted system call */
+const i32 EIO          =   5;  /* I/O error */
+const i32 ENXIO        =   6;  /* No such device or address */
+const i32 E2BIG        =   7;  /* Argument list too long */
+const i32 ENOEXEC      =   8;  /* Exec format error */
+const i32 EBADF        =   9;  /* Bad file number */
+const i32 ECHILD       =  10;  /* No child processes */
+const i32 EAGAIN       =  35;  /* Try again */
+const i32 ENOMEM       =  12;  /* Out of memory */
+const i32 EACCES       =  13;  /* Permission denied */
+const i32 EFAULT       =  14;  /* Bad address */
+const i32 ENOTBLK      =  15;  /* Block device required */
+const i32 EBUSY        =  16;  /* Device or resource busy */
+const i32 EEXIST       =  17;  /* File exists */
+const i32 EXDEV        =  18;  /* Cross-device link */
+const i32 ENODEV       =  19;  /* No such device */
+const i32 ENOTDIR      =  20;  /* Not a directory */
+const i32 EISDIR       =  21;  /* Is a directory */
+const i32 EINVAL       =  22;  /* Invalid argument */
+const i32 ENFILE       =  23;  /* File table overflow */
+const i32 EMFILE       =  24;  /* Too many open files */
+const i32 ENOTTY       =  25;  /* Not a typewriter */
+const i32 ETXTBSY      =  26;  /* Text file busy */
+const i32 EFBIG        =  27;  /* File too large */
+const i32 ENOSPC       =  28;  /* No space left on device */
+const i32 ESPIPE       =  29;  /* Illegal seek */
+const i32 EROFS        =  30;  /* Read-only file system */
+const i32 EMLINK       =  31;  /* Too many links */
+const i32 EPIPE        =  32;  /* Broken pipe */
+const i32 EDOM         =  33;  /* Math argument out of domain of func */
+const i32 ERANGE       =  34;  /* Math result not representable */
+const i32 EALREADY     =  37;  /* Operation already in progress */
+const i32 EINPROGRESS  =  36;  /* Operation now in progress */
+const i32 ESTALE       =  70;  /* Stale file handle */
+#else
 const i32 EPERM        = 1;  /* Operation not permitted */
 const i32 ENOENT       = 2;  /* No such file or directory */
 const i32 ESRCH        = 3;  /* No such process */
@@ -48,4 +91,4 @@ const i32 ERANGE      = 34;  /* Math result not representable */
 const i32 EALREADY    = 114; /* Operation already in progress */
 const i32 EINPROGRESS = 115; /* Operation now in progress */
 const i32 ESTALE      = 116; /* Stale file handle */
-
+#endif

--- a/libc/csetjmp.c2i
+++ b/libc/csetjmp.c2i
@@ -3,7 +3,7 @@ module csetjmp;
 import c2 local;
 
 type JmpBufTag struct @(cname="__jmp_buf_tag", aligned=8) {
-#if DARWIN_ARM64
+#if SYSTEM_DARWIN
     // Should be i32[((14 + 8 + 2) * 2)] data;
     // but size is tested explicitly in
     // test/globals/static_asserts/static_assert_jmpbuf.c2

--- a/libc/csetjmp.c2i
+++ b/libc/csetjmp.c2i
@@ -3,7 +3,16 @@ module csetjmp;
 import c2 local;
 
 type JmpBufTag struct @(cname="__jmp_buf_tag", aligned=8) {
+#if DARWIN_ARM64
+    // Should be i32[((14 + 8 + 2) * 2)] data;
+    // but size is tested explicitly in
+    // test/globals/static_asserts/static_assert_jmpbuf.c2
+    // and 200 > 192, so this is just suboptimal.
+    //i32[((14 + 8 + 2) * 2)] data;
+    char[200] data;
+#else
     char[200] data; // for 64-bit
+#endif
 }
 
 type JmpBuf JmpBufTag* @(cname="jmp_buf");
@@ -20,6 +29,7 @@ fn c_uint sleep(c_uint __seconds);
 fn c_char* getcwd(char* buf, c_size size);
 fn c_int chdir(const c_char* path);
 
+// FIXME: these belong in unistd.c2
 const u8 R_OK = 4;
 const u8 W_OK = 2;
 const u8 X_OK = 1;

--- a/libc/libc_dirent.c2i
+++ b/libc/libc_dirent.c2i
@@ -21,7 +21,7 @@ fn c_int scandir(const c_char* dirp, Dirent*** namelist,
 fn c_int alphasort(const Dirent**, const Dirent**);
 fn c_int versionsort(const Dirent**, const Dirent**);
 
-#if DARWIN_ARM64
+#if SYSTEM_DARWIN
 type Dirent struct @(cname="dirent") {
     c_ulonglong d_ino;
     c_ulonglong d_seekoff;

--- a/libc/libc_dirent.c2i
+++ b/libc/libc_dirent.c2i
@@ -21,6 +21,16 @@ fn c_int scandir(const c_char* dirp, Dirent*** namelist,
 fn c_int alphasort(const Dirent**, const Dirent**);
 fn c_int versionsort(const Dirent**, const Dirent**);
 
+#if DARWIN_ARM64
+type Dirent struct @(cname="dirent") {
+    c_ulonglong d_ino;
+    c_ulonglong d_seekoff;
+    c_ushort d_reclen;
+    c_ushort d_namlen;
+    u8 d_type;
+    char[1024] d_name;
+}
+#else
 type Dirent struct @(cname="dirent") {
    c_ulonglong  d_ino;
    c_longlong   d_off;
@@ -28,6 +38,7 @@ type Dirent struct @(cname="dirent") {
    u8           d_type;
    char[256]    d_name;
 }
+#endif
 
 const c_uint DT_UNKNOWN = 0;
 const c_uint DT_FIFO = 1;

--- a/libc/libc_fcntl.c2i
+++ b/libc/libc_fcntl.c2i
@@ -2,6 +2,21 @@ module libc_fcntl;
 
 import c2 local;
 
+#if DARWIN_ARM64
+const u32 O_RDONLY    =        0;
+const u32 O_WRONLY    =       01;
+const u32 O_RDWR      =       02;
+const u32 O_CREAT     =    01000;
+const u32 O_EXCL      =    04000;
+const u32 O_NOCTTY    =  0400000;
+const u32 O_TRUNC     =    02000;
+const u32 O_APPEND    =      010;
+const u32 O_NONBLOCK  =       04;
+const u32 O_DIRECTORY = 04000000;
+const u32 O_NOFOLLOW  =     0400;
+const u32 O_SYNC      =     0200;
+const u32 O_CLOEXEC   =0100000000;
+#else
 const u32 O_RDONLY    =       00;
 const u32 O_WRONLY    =       01;
 const u32 O_RDWR      =       02;
@@ -20,6 +35,7 @@ const u32 O_NOATIME   = 01000000;
 const u32 O_CLOEXEC   = 02000000;
 const u32 O_PATH      =010000000;
 const u32 O_TMPFILE   =020000000;
+#endif
 
 const u32 F_DUPFD = 0;
 const u32 F_GETFD = 1;
@@ -27,7 +43,11 @@ const u32 F_SETFD = 2;
 const u32 F_GETFL = 3;
 const u32 F_SETFL = 4;
 
+#if DARWIN_ARM64
+const i32 AT_FDCWD = -2;
+#else
 const i32 AT_FDCWD = -100;  // Linux specific
+#endif
 
 const u32 FD_CLOEXEC = 1;
 

--- a/libc/libc_fcntl.c2i
+++ b/libc/libc_fcntl.c2i
@@ -2,7 +2,7 @@ module libc_fcntl;
 
 import c2 local;
 
-#if DARWIN_ARM64
+#if SYSTEM_DARWIN
 const u32 O_RDONLY    =        0;
 const u32 O_WRONLY    =       01;
 const u32 O_RDWR      =       02;
@@ -43,7 +43,7 @@ const u32 F_SETFD = 2;
 const u32 F_GETFL = 3;
 const u32 F_SETFL = 4;
 
-#if DARWIN_ARM64
+#if SYSTEM_DARWIN
 const i32 AT_FDCWD = -2;
 #else
 const i32 AT_FDCWD = -100;  // Linux specific

--- a/libc/stdio.c2i
+++ b/libc/stdio.c2i
@@ -103,7 +103,7 @@ fn c_int ftrylockfile(FILE* __stream);
 fn void funlockfile(FILE* __stream);
 
 // --- Linux only ---
-#if __USE_LARGEFIE64
+#if __USE_LARGEFILE64
 fn FILE* tmpfile64(void);
 #endif
 fn c_char* tmpnam_r(c_char* __s);

--- a/libc/stdio.c2i
+++ b/libc/stdio.c2i
@@ -31,13 +31,15 @@ type Offset u64 @(cname="off_t");
 //NOTE: _G_fpos_t is some struct(_G_fpos_t.h)
 //type fpos_t _G_fpos_t;
 
+#if SYSTEM_DARWIN
+FILE* stdin @(cname="__stdinp");
+FILE* stdout @(cname="__stdoutp");
+FILE* stderr @(cname="__stderrp");
+#else
 FILE* stdin;
 FILE* stdout;
 FILE* stderr;
-
-// MAC OS (BSD?)
-//#define stderr __stderrp;
-//FILE* __stderrp;
+#endif
 
 fn c_int remove(const c_char* __filename);
 

--- a/libc/sys_mman.c2i
+++ b/libc/sys_mman.c2i
@@ -8,7 +8,7 @@ fn void* mmap(void* addr, c_size length, c_int prot, c_int flags, c_int fd, Offs
 
 fn c_int munmap(void* addr, c_size length);
 
-#if DARWIN_ARM64
+#if SYSTEM_DARWIN
 const u32 PROT_NONE = 0;
 const u32 PROT_READ = 1;
 const u32 PROT_WRITE = 2;

--- a/libc/sys_mman.c2i
+++ b/libc/sys_mman.c2i
@@ -8,10 +8,22 @@ fn void* mmap(void* addr, c_size length, c_int prot, c_int flags, c_int fd, Offs
 
 fn c_int munmap(void* addr, c_size length);
 
+#if DARWIN_ARM64
+const u32 PROT_NONE = 0;
+const u32 PROT_READ = 1;
+const u32 PROT_WRITE = 2;
+const u32 PROT_EXEC = 4;
+
+const u32 MAP_SHARED = 0x01;
+const u32 MAP_PRIVATE = 0x02;
+const u32 MAP_FIXED = 0x10;
+const u32 MAP_ANONYMOUS = 0x1000;
+const usize MAP_FAILED = -1;
+#else
 const u32 PROT_NONE  = 0x0;
 const u32 PROT_READ  = 0x1;
 const u32 PROT_WRITE = 0x2;
-const u32 PROT_EXIT  = 0x4;
+const u32 PROT_EXEC  = 0x4;
 
 //NOTE: not all constants have been added yet
 const u32 MAP_SHARED    = 0x01;
@@ -23,3 +35,4 @@ const u32 MAP_POPULATE  = 0x8000;
 const usize MAP_FAILED  = -1;
 //const void* MAP_FAILED  = max_u64;
 //const void* MAP_FAILED  = max_u32;
+#endif

--- a/libc/sys_stat.c2i
+++ b/libc/sys_stat.c2i
@@ -2,7 +2,7 @@ module sys_stat;
 
 import c2 local;
 
-#if DARWIN_ARM64
+#if SYSTEM_DARWIN
 type Timespec struct @(cname="timespec", no_typedef) {
     c_long tv_sec;
     c_long tv_nsec;

--- a/libc/sys_stat.c2i
+++ b/libc/sys_stat.c2i
@@ -2,6 +2,32 @@ module sys_stat;
 
 import c2 local;
 
+#if DARWIN_ARM64
+type Timespec struct @(cname="timespec", no_typedef) {
+    c_long tv_sec;
+    c_long tv_nsec;
+}
+type Stat struct @(cname="stat", no_typedef) {
+    c_int st_dev;
+    c_ushort st_mode;
+    c_ushort st_nlink;
+    c_ulong st_ino;
+    c_uint st_uid;
+    c_uint st_gid;
+    c_uint st_rdev;
+    Timespec st_atimespec;
+    Timespec st_mtimespec;
+    Timespec st_ctimespec;
+    Timespec st_birthtimespec;
+    c_ulong st_size;
+    c_ulong st_blocks;
+    c_uint st_blksize;
+    c_uint st_flags;
+    c_uint st_gen;
+    c_int st_lspare;
+    c_long[2] st_qspare;
+}
+#else
 // Version for Ubuntu 18.04
 type Stat struct @(cname="stat", no_typedef) {
     c_ulong st_dev;
@@ -29,6 +55,7 @@ type Stat struct @(cname="stat", no_typedef) {
     c_uint  __unused5;
     c_long[2] reserved;
 }
+#endif
 
 fn c_int fstat(c_int fd, Stat* buf);
 // NOTE: cannot have stat function also... (clashes with stat struct)

--- a/libc/sys_utsname.c2i
+++ b/libc/sys_utsname.c2i
@@ -2,7 +2,11 @@ module sys_utsname;
 
 import c2 local;
 
+#if DARWIN_ARM64
+const c_uint NAME_LEN = 256;
+#else
 const c_uint NAME_LEN = 65;
+#endif
 
 type Name struct @(cname="utsname") {
     char[NAME_LEN] sysname;

--- a/libc/sys_utsname.c2i
+++ b/libc/sys_utsname.c2i
@@ -2,7 +2,7 @@ module sys_utsname;
 
 import c2 local;
 
-#if DARWIN_ARM64
+#if SYSTEM_DARWIN
 const c_uint NAME_LEN = 256;
 #else
 const c_uint NAME_LEN = 65;

--- a/libc/unistd.c2i
+++ b/libc/unistd.c2i
@@ -74,7 +74,7 @@ fn c_int kill(Pid pid, c_int signal);
 
 fn c_long sysconf(c_int name);
 
-#if DARWIN_ARM64
+#if SYSTEM_DARWIN
 const u32 _SC_ARG_MAX = 1;
 const u32 _SC_CHILD_MAX = 2;
 const u32 _SC_CLK_TCK = 3;

--- a/libc/unistd.c2i
+++ b/libc/unistd.c2i
@@ -74,6 +74,99 @@ fn c_int kill(Pid pid, c_int signal);
 
 fn c_long sysconf(c_int name);
 
+#if DARWIN_ARM64
+const u32 _SC_ARG_MAX = 1;
+const u32 _SC_CHILD_MAX = 2;
+const u32 _SC_CLK_TCK = 3;
+const u32 _SC_NGROUPS_MAX = 4;
+const u32 _SC_OPEN_MAX = 5;
+const u32 _SC_JOB_CONTROL = 6;
+const u32 _SC_SAVED_IDS = 7;
+const u32 _SC_VERSION = 8;
+const u32 _SC_PAGESIZE = 29;
+const u32 _SC_PAGE_SIZE = 29;
+const u32 _SC_NPROCESSORS_CONF = 57;
+const u32 _SC_NPROCESSORS_ONLN = 58;
+const u32 _SC_PHYS_PAGES = 200;
+const u32 _SC_MQ_OPEN_MAX = 46;
+const u32 _SC_MQ_PRIO_MAX = 75;
+const u32 _SC_RTSIG_MAX = 48;
+const u32 _SC_SEM_NSEMS_MAX = 49;
+const u32 _SC_SEM_VALUE_MAX = 50;
+const u32 _SC_SIGQUEUE_MAX = 51;
+const u32 _SC_TIMER_MAX = 52;
+const u32 _SC_TZNAME_MAX = 27;
+const u32 _SC_ASYNCHRONOUS_IO = 28;
+const u32 _SC_FSYNC = 38;
+const u32 _SC_MAPPED_FILES = 47;
+const u32 _SC_MEMLOCK = 30;
+const u32 _SC_MEMLOCK_RANGE = 31;
+const u32 _SC_MEMORY_PROTECTION = 32;
+const u32 _SC_MESSAGE_PASSING = 33;
+const u32 _SC_PRIORITIZED_IO = 34;
+const u32 _SC_REALTIME_SIGNALS = 36;
+const u32 _SC_SEMAPHORES = 37;
+const u32 _SC_SHARED_MEMORY_OBJECTS = 39;
+const u32 _SC_SYNCHRONIZED_IO = 40;
+const u32 _SC_TIMERS = 41;
+const u32 _SC_AIO_LISTIO_MAX = 42;
+const u32 _SC_AIO_MAX = 43;
+const u32 _SC_AIO_PRIO_DELTA_MAX = 44;
+const u32 _SC_DELAYTIMER_MAX = 45;
+const u32 _SC_THREAD_KEYS_MAX = 86;
+const u32 _SC_THREAD_STACK_MIN = 93;
+const u32 _SC_THREAD_THREADS_MAX = 94;
+const u32 _SC_TTY_NAME_MAX = 101;
+const u32 _SC_THREADS = 96;
+const u32 _SC_THREAD_ATTR_STACKADDR = 82;
+const u32 _SC_THREAD_ATTR_STACKSIZE = 83;
+const u32 _SC_THREAD_PRIORITY_SCHEDULING = 89;
+const u32 _SC_THREAD_PRIO_INHERIT = 87;
+const u32 _SC_THREAD_PRIO_PROTECT = 88;
+const u32 _SC_THREAD_PROCESS_SHARED = 90;
+const u32 _SC_THREAD_SAFE_FUNCTIONS = 91;
+const u32 _SC_GETGR_R_SIZE_MAX = 70;
+const u32 _SC_GETPW_R_SIZE_MAX = 71;
+const u32 _SC_LOGIN_NAME_MAX = 73;
+const u32 _SC_ADVISORY_INFO = 65;
+const u32 _SC_ATEXIT_MAX = 107;
+const u32 _SC_BARRIERS = 66;
+const u32 _SC_BC_BASE_MAX = 9;
+const u32 _SC_BC_DIM_MAX = 10;
+const u32 _SC_BC_SCALE_MAX = 11;
+const u32 _SC_BC_STRING_MAX = 12;
+const u32 _SC_CLOCK_SELECTION = 67;
+const u32 _SC_COLL_WEIGHTS_MAX = 13;
+const u32 _SC_CPUTIME = 68;
+const u32 _SC_EXPR_NEST_MAX = 14;
+const u32 _SC_HOST_NAME_MAX = 72;
+const u32 _SC_IOV_MAX = 56;
+const u32 _SC_IPV6 = 118;
+const u32 _SC_LINE_MAX = 15;
+const u32 _SC_MONOTONIC_CLOCK = 74;
+const u32 _SC_RAW_SOCKETS = 119;
+const u32 _SC_READER_WRITER_LOCKS = 76;
+const u32 _SC_REGEXP = 77;
+const u32 _SC_RE_DUP_MAX = 16;
+const u32 _SC_SHELL = 78;
+const u32 _SC_SPAWN = 79;
+const u32 _SC_SPIN_LOCKS = 80;
+const u32 _SC_SPORADIC_SERVER = 81;
+const u32 _SC_SS_REPL_MAX = 126;
+const u32 _SC_SYMLOOP_MAX = 120;
+const u32 _SC_THREAD_CPUTIME = 84;
+const u32 _SC_THREAD_SPORADIC_SERVER = 92;
+const u32 _SC_TIMEOUTS = 95;
+const u32 _SC_TRACE = 97;
+const u32 _SC_TRACE_EVENT_FILTER = 98;
+const u32 _SC_TRACE_EVENT_NAME_MAX = 127;
+const u32 _SC_TRACE_INHERIT = 99;
+const u32 _SC_TRACE_LOG = 100;
+const u32 _SC_TRACE_NAME_MAX = 128;
+const u32 _SC_TRACE_SYS_MAX = 129;
+const u32 _SC_TRACE_USER_EVENT_MAX = 130;
+const u32 _SC_TYPED_MEMORY_OBJECTS = 102;
+#else
 // sysconf values per IEEE Std 1003.1, 2008 Edition
 // TODO not correct for linux
 /*
@@ -175,6 +268,7 @@ const u32 _SC_TRACE_USER_EVENT_MAX         = 90;
 const u32 _SC_TYPED_MEMORY_OBJECTS         = 91;
 const u32 _SC_V7_ILP32_OFF32               = 92;
 */
+#endif
 
 fn c_ulong lseek (i32 fd, c_ulong offset, i32 whence);
 

--- a/pthread/pthread.c2i
+++ b/pthread/pthread.c2i
@@ -2,11 +2,27 @@ module pthread;
 
 import c2 local;
 
+// NOTE: depends on architecture
+#if DARWIN_ARM64
+const u32 SIZEOF_ATTR_T = 64;
+const u32 SIZEOF_MUTEX_T = 64;
+const u32 SIZEOF_MUTEXATTR_T = 16;
+const u32 SIZEOF_COND_T = 48;
+const u32 SIZEOF_CONDATTR_T = 16;
+#else
+const u32 SIZEOF_ATTR_T = 64;
+const u32 SIZEOF_MUTEX_T = 40;
+const u32 SIZEOF_MUTEXATTR_T = 4;
+const u32 SIZEOF_COND_T = 48;
+const u32 SIZEOF_CONDATTR_T = 4;
+#endif
+
 // -------- pthread --------
 type Pthread c_ulong @(cname="pthread_t");
 
+// FIXME: should be union?
 type PthreadAttr struct @(cname="pthread_attr_t") {
-    c_char[64]  __size; // NOTE: 32 on 32-bit
+    char[SIZEOF_ATTR_T]  __size; // NOTE: 32 on 32-bit
     c_long __align;
 }
 
@@ -19,12 +35,9 @@ fn c_int create(Pthread* __newthread,
 
 fn c_int join(Pthread thread, void** value_ptr) @(cname="pthread_join");
 
-fn c_int self() @(cname="pthread_self");
+fn Pthread self() @(cname="pthread_self");
 
 // -------- mutex --------
-// NOTE: depends on architecture
-const u32 SIZEOF_MUTEX_T = 40;
-const u32 SIZEOF_MUTEXATTR_T = 4;
 
 type Mutex union @(cname="pthread_mutex_t") {
     //struct __pthread_mutex_s __data;
@@ -34,7 +47,7 @@ type Mutex union @(cname="pthread_mutex_t") {
 
 type MutexAttr union @(cname="pthread_mutexattr_t") {
     char[SIZEOF_MUTEXATTR_T] size;
-    c_int align;
+    c_long align;
 }
 
 fn c_int Mutex.init(Mutex* mutex, const MutexAttr* attr) @(cname="pthread_mutex_init");
@@ -46,9 +59,6 @@ fn c_int Mutex.unlock(Mutex* mutex) @(cname="pthread_mutex_unlock");
 
 
 // -------- cond --------
-// NOTE: depends on architecture
-const u32 SIZEOF_COND_T = 48;
-const u32 SIZEOF_CONDATTR_T = 4;
 
 type Cond union @(cname="pthread_cond_t") {
     //struct __pthread_mutex_s __data;
@@ -58,7 +68,7 @@ type Cond union @(cname="pthread_cond_t") {
 
 type CondAttr union @(cname="pthread_condattr_t") {
     char[SIZEOF_CONDATTR_T] size;
-    c_int align;
+    c_long align;
 }
 
 fn c_int Cond.init(Cond* cond, const CondAttr* attr) @(cname="pthread_cond_init");

--- a/pthread/pthread.c2i
+++ b/pthread/pthread.c2i
@@ -3,7 +3,7 @@ module pthread;
 import c2 local;
 
 // NOTE: depends on architecture
-#if DARWIN_ARM64
+#if SYSTEM_DARWIN
 const u32 SIZEOF_ATTR_T = 64;
 const u32 SIZEOF_MUTEX_T = 64;
 const u32 SIZEOF_MUTEXATTR_T = 16;


### PR DESCRIPTION
Use `#if SYSTEM_DARWIN` preprocessing to select actual layout and alignment for system
  structures and global constant definitions:
* `jmp_buf`, `dirent`, `fcntl`, `stdio`, `sys_mman`, `sys_stat`, `sys_utsname`, `unistd`,
* `pthread`